### PR TITLE
Add Gateway API support

### DIFF
--- a/templates/si-backend-tls-policy.yaml
+++ b/templates/si-backend-tls-policy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.backendTLS.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-backend-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-headless
+      sectionName: management
+  validation:
+    hostname: {{ default (printf "%s-%s-headless.%s.svc" (include "resource.prefix" .) .Release.Name .Release.Namespace) .Values.wso2.gatewayApi.backendTLS.hostname | quote }}
+    {{- if .Values.wso2.gatewayApi.backendTLS.caCertRefs }}
+    caCertificateRefs:
+{{ toYaml .Values.wso2.gatewayApi.backendTLS.caCertRefs | indent 6 }}
+    {{- else }}
+    wellKnownCACertificates: System
+    {{- end }}
+{{- end }}

--- a/templates/si-backend-tls-policy.yaml
+++ b/templates/si-backend-tls-policy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.backendTLS.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-backend-traffic-policy.yaml
+++ b/templates/si-backend-traffic-policy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.rateLimit.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-backend-traffic-policy.yaml
+++ b/templates/si-backend-traffic-policy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.rateLimit.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+#
+# Envoy-Gateway-specific resource. Not portable to other Gateway API implementations.
+#
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-rate-limit
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
+  rateLimit:
+    type: Local
+    local:
+      rules:
+        - limit:
+            requests: {{ .Values.wso2.gatewayApi.rateLimit.requests }}
+            unit: {{ .Values.wso2.gatewayApi.rateLimit.unit | quote }}
+{{- end }}

--- a/templates/si-gateway.yaml
+++ b/templates/si-gateway.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.gateway.create }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.wso2.gatewayApi.gateway.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  gatewayClassName: {{ .Values.wso2.gatewayApi.gatewayClassName | quote }}
+  listeners:
+    - name: {{ .Values.wso2.gatewayApi.gateway.listenerName | quote }}
+      port: {{ .Values.wso2.gatewayApi.gateway.port }}
+      protocol: HTTPS
+      hostname: {{ .Values.wso2.deployment.hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: {{ .Values.wso2.gatewayApi.gateway.tlsSecret | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+{{- end }}

--- a/templates/si-gateway.yaml
+++ b/templates/si-gateway.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.gateway.create }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-httproute.yaml
+++ b/templates/si-httproute.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.wso2.gatewayApi.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-httproute.yaml
+++ b/templates/si-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.wso2.gatewayApi.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.wso2.gatewayApi.gateway.name | quote }}
+      {{- if and (not .Values.wso2.gatewayApi.gateway.create) .Values.wso2.gatewayApi.gateway.namespace }}
+      namespace: {{ .Values.wso2.gatewayApi.gateway.namespace | quote }}
+      {{- else }}
+      namespace: {{ .Release.Namespace | quote }}
+      {{- end }}
+      sectionName: {{ .Values.wso2.gatewayApi.gateway.listenerName | quote }}
+  hostnames:
+    - {{ .Values.wso2.deployment.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /siddhi-apps
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-headless
+          port: {{ .Values.wso2.config.transport.http.msf4jHttps }}
+{{- end }}

--- a/templates/si-ingress.yaml
+++ b/templates/si-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.wso2.ingress.enabled }}
+{{- if and .Values.wso2.ingress.enabled (not .Values.wso2.gatewayApi.enabled) }}
 # ------------------------------------------------------------------------------------
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
 #

--- a/values.yaml
+++ b/values.yaml
@@ -106,7 +106,7 @@ wso2:
     # -- WSO2 subscription password
     password: ""
   ingress:
-    # -- Enable Ingress for SI
+    # -- Enable Ingress for SI. Mutually exclusive with wso2.gatewayApi.enabled.
     enabled: true
     # -- Ingress class name
     ingressClassName: "nginx"
@@ -125,6 +125,44 @@ wso2:
       zoneName: ""
       # -- Ingress ratelimit burst limit
       burstLimit: ""
+  # Gateway API configuration. Use this instead of wso2.ingress when routing through
+  # Envoy Gateway or any other Gateway-API-conformant controller. Set wso2.ingress.enabled=false
+  # when wso2.gatewayApi.enabled=true.
+  gatewayApi:
+    # -- Enable Gateway API resources (HTTPRoute, optional Gateway, optional policies) for SI.
+    enabled: false
+    # -- GatewayClass name. Examples: "eg" (Envoy Gateway), "istio", "contour".
+    gatewayClassName: "eg"
+    gateway:
+      # -- If true, the chart creates a Gateway resource. If false, an existing Gateway is referenced.
+      create: true
+      # -- Name of the Gateway. Used for both create=true and create=false modes.
+      name: "si-gateway"
+      # -- Namespace of the Gateway when create=false. Ignored when create=true (chart uses release namespace).
+      namespace: ""
+      # -- Listener name on the Gateway that the HTTPRoute attaches to.
+      listenerName: "https"
+      # -- Listener port. Typically 443 for HTTPS termination.
+      port: 443
+      # -- K8s TLS secret used to terminate TLS at the Gateway listener (only when create=true).
+      tlsSecret: ""
+    backendTLS:
+      # -- Issue a BackendTLSPolicy so the Gateway speaks HTTPS to the SI backend (msf4jHttps).
+      # Required when routing to the secure transport port. Gateway API v1.1+.
+      enabled: true
+      # -- Hostname used for backend SNI/cert verification. Defaults to the service name when empty.
+      hostname: ""
+      # -- (list) ConfigMap refs containing CA certs to validate the backend cert.
+      # Format: [{name: "<cm-name>"}]. Leave empty to use the well-known CA bundle.
+      caCertRefs:
+    rateLimit:
+      # -- Apply an Envoy Gateway BackendTrafficPolicy for local rate limiting.
+      # Envoy-Gateway-specific extension; not portable across Gateway API implementations.
+      enabled: false
+      # -- Number of requests permitted per unit.
+      requests: 100
+      # -- Time window. One of: Second, Minute, Hour, Day.
+      unit: "Second"
   config:
     admin:
       # -- Super admin username

--- a/values.yaml
+++ b/values.yaml
@@ -149,11 +149,21 @@ wso2:
     backendTLS:
       # -- Issue a BackendTLSPolicy so the Gateway speaks HTTPS to the SI backend (msf4jHttps).
       # Required when routing to the secure transport port. Gateway API v1.1+.
+      #
+      # NOTE: SI's default `wso2carbon.jks` keystore ships a self-signed cert with `CN=localhost`
+      # and no SubjectAltName. Modern Gateway implementations (Envoy Gateway, Istio) reject this
+      # under strict TLS verification regardless of the CA. For the policy to result in successful
+      # backend connections, replace `wso2carbon.jks` with a properly-issued cert whose SAN includes
+      # the service FQDN (e.g. `cloud-<release>-headless.<namespace>.svc`) and provide its CA below.
       enabled: true
-      # -- Hostname used for backend SNI/cert verification. Defaults to the service name when empty.
+      # -- Hostname used for backend SNI/cert verification. Defaults to the service FQDN when empty.
       hostname: ""
       # -- (list) ConfigMap refs containing CA certs to validate the backend cert.
-      # Format: [{name: "<cm-name>"}]. Leave empty to use the well-known CA bundle.
+      # Each entry must specify group, kind, and name. Format:
+      #   - group: ""
+      #     kind: ConfigMap
+      #     name: <configmap-name>
+      # Leave empty to use the well-known CA bundle (System trust store).
       caCertRefs:
     rateLimit:
       # -- Apply an Envoy Gateway BackendTrafficPolicy for local rate limiting.


### PR DESCRIPTION
Adds an opt-in Gateway API path (Envoy Gateway tested) alongside the existing NGINX Ingress, in response to the upstream ingress-nginx maintenance-mode situation. Existing users keep the Ingress path with no change.

Set `wso2.gatewayApi.enabled=true` (and `wso2.ingress.enabled=false`) to opt in. New templates: HTTPRoute, optional Gateway, optional BackendTLSPolicy, optional Envoy-Gateway BackendTrafficPolicy for rate limit.

## Test plan
- [x] `helm lint` clean for ingress mode, gateway-api mode, both-flags-on
- [x] `helm template` renders correct kind set per scenario (Ingress only / HTTPRoute+Gateway+policies / cross-namespace attach)
- [ ] End-to-end on a live cluster with Envoy Gateway installed