### PR TITLE
Add Gateway API support

### DIFF
--- a/templates/si-backend-tls-policy.yaml
+++ b/templates/si-backend-tls-policy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.backendTLS.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-backend-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-headless
+      sectionName: management
+  validation:
+    hostname: {{ default (printf "%s-%s-headless.%s.svc" (include "resource.prefix" .) .Release.Name .Release.Namespace) .Values.wso2.gatewayApi.backendTLS.hostname | quote }}
+    {{- if .Values.wso2.gatewayApi.backendTLS.caCertRefs }}
+    caCertificateRefs:
+{{ toYaml .Values.wso2.gatewayApi.backendTLS.caCertRefs | indent 6 }}
+    {{- else }}
+    wellKnownCACertificates: System
+    {{- end }}
+{{- end }}

--- a/templates/si-backend-tls-policy.yaml
+++ b/templates/si-backend-tls-policy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.backendTLS.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-backend-traffic-policy.yaml
+++ b/templates/si-backend-traffic-policy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.rateLimit.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-backend-traffic-policy.yaml
+++ b/templates/si-backend-traffic-policy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.rateLimit.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+# NOTE: BackendTrafficPolicy is an Envoy Gateway-specific extension (gateway.envoyproxy.io/v1alpha1).
+# It is not portable to other Gateway API implementations such as Istio or Cilium Gateway.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-rate-limit
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
+  rateLimit:
+    type: Local
+    local:
+      rules:
+        - limit:
+            requests: {{ .Values.wso2.gatewayApi.rateLimit.requests }}
+            unit: {{ .Values.wso2.gatewayApi.rateLimit.unit }}
+{{- end }}

--- a/templates/si-gateway.yaml
+++ b/templates/si-gateway.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.gateway.create }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-gateway.yaml
+++ b/templates/si-gateway.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.wso2.gatewayApi.enabled .Values.wso2.gatewayApi.gateway.create }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.wso2.gatewayApi.gateway.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  gatewayClassName: {{ .Values.wso2.gatewayApi.gatewayClassName | quote }}
+  listeners:
+    - name: {{ .Values.wso2.gatewayApi.gateway.listenerName | quote }}
+      protocol: HTTPS
+      port: {{ .Values.wso2.gatewayApi.gateway.port }}
+      hostname: {{ .Values.wso2.deployment.hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ required "wso2.gatewayApi.gateway.tlsSecret must be set when wso2.gatewayApi.gateway.create is true" .Values.wso2.gatewayApi.gateway.tlsSecret | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+{{- end }}

--- a/templates/si-httproute.yaml
+++ b/templates/si-httproute.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.wso2.gatewayApi.enabled }}
 # ------------------------------------------------------------------------------------
-# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except

--- a/templates/si-httproute.yaml
+++ b/templates/si-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.wso2.gatewayApi.enabled }}
+# ------------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#------------------------------------------------------------------------------------
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "streaming-integrator.labels" . | indent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.wso2.gatewayApi.gateway.name | quote }}
+      {{- if and (not .Values.wso2.gatewayApi.gateway.create) .Values.wso2.gatewayApi.gateway.namespace }}
+      namespace: {{ .Values.wso2.gatewayApi.gateway.namespace | quote }}
+      {{- else }}
+      namespace: {{ .Release.Namespace | quote }}
+      {{- end }}
+      sectionName: {{ .Values.wso2.gatewayApi.gateway.listenerName | quote }}
+  hostnames:
+    - {{ .Values.wso2.deployment.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /siddhi-apps
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-headless
+          port: {{ .Values.wso2.config.transport.http.msf4jHttps }}
+{{- end }}

--- a/templates/si-httproute.yaml
+++ b/templates/si-httproute.yaml
@@ -46,5 +46,9 @@ spec:
         - group: ""
           kind: Service
           name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-headless
+          {{- if .Values.wso2.gatewayApi.backendTLS.enabled }}
           port: {{ .Values.wso2.config.transport.http.msf4jHttps }}
+          {{- else }}
+          port: {{ .Values.wso2.config.transport.http.default }}
+          {{- end }}
 {{- end }}

--- a/templates/si-ingress.yaml
+++ b/templates/si-ingress.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.wso2.ingress.enabled }}
+{{- $gatewayApiEnabled := false -}}
+{{- if hasKey .Values.wso2 "gatewayApi" -}}
+  {{- $gatewayApiEnabled = .Values.wso2.gatewayApi.enabled | default false -}}
+{{- end -}}
+{{- if and .Values.wso2.ingress.enabled (not $gatewayApiEnabled) }}
 # ------------------------------------------------------------------------------------
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
 #

--- a/values.yaml
+++ b/values.yaml
@@ -125,6 +125,45 @@ wso2:
       zoneName: ""
       # -- Ingress ratelimit burst limit
       burstLimit: ""
+  # Gateway API configuration — enable as an alternative to Ingress.
+  # Tested with Envoy Gateway. Disable ingress when enabling Gateway API.
+  # NOTE: SI ships with a self-signed cert (CN=localhost, no SANs). Enable backendTLS
+  # only after replacing the default cert with one that has proper SANs, otherwise
+  # the gateway will fail to establish TLS to the backend.
+  gatewayApi:
+    # -- Enable Gateway API routing (set wso2.ingress.enabled=false when enabling this)
+    enabled: false
+    # -- GatewayClass name (e.g. "eg" for Envoy Gateway)
+    gatewayClassName: "eg"
+    gateway:
+      # -- Create a Gateway resource managed by this chart. Set false to reference an existing Gateway.
+      create: true
+      # -- Name of the Gateway resource
+      name: "si-gateway"
+      # -- Namespace of an externally-managed Gateway (only used when create=false)
+      namespace: ""
+      # -- Listener name on the Gateway
+      listenerName: "https"
+      # -- HTTPS listener port
+      port: 443
+      # -- K8s TLS secret name for HTTPS termination. Required when gateway.create=true.
+      tlsSecret: ""
+    backendTLS:
+      # -- Enable BackendTLSPolicy for TLS validation between gateway and SI backend.
+      # Requires a valid certificate with proper SANs. SI's default self-signed cert
+      # (CN=localhost) will cause validation failures — replace it before enabling.
+      enabled: false
+      # -- Override the validation hostname. Defaults to the headless service FQDN.
+      hostname: ""
+      # -- (list) CA certificate refs for backend TLS validation. If empty, system CAs are used.
+      caCertRefs:
+    rateLimit:
+      # -- Enable rate limiting via Envoy Gateway BackendTrafficPolicy (Envoy Gateway-specific, not portable)
+      enabled: false
+      # -- Maximum number of requests allowed per unit
+      requests: 100
+      # -- Time unit for rate limiting (Second, Minute, Hour)
+      unit: "Second"
   config:
     admin:
       # -- Super admin username


### PR DESCRIPTION
Adds an opt-in Gateway API path (Envoy Gateway tested) alongside the existing NGINX Ingress, in response to the upstream ingress-nginx maintenance-mode situation. Existing users keep the Ingress path with no change.

Set wso2.gatewayApi.enabled=true (and wso2.ingress.enabled=false) to opt in. New templates: HTTPRoute, optional Gateway, optional BackendTLSPolicy, optional Envoy-Gateway BackendTrafficPolicy for rate limit.

