### PR TITLE
Bump chart to SI 4.4.0

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,6 +1,6 @@
 # si
 
-![Version: 4.3.0-0](https://img.shields.io/badge/Version-4.3.0--0-informational?style=flat-square) ![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
+![Version: 4.4.0-0](https://img.shields.io/badge/Version-4.4.0--0-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 Streaming Integrator
 
@@ -87,7 +87,7 @@ A Helm chart for the deployment of WSO2 Streaming Integrator
 | wso2.config.transport.http.msf4jHttps | int | `9443` |  |
 | wso2.config.trustStore.primary.fileName | string | `"client-truststore.jks"` | Primary truststore file name |
 | wso2.config.trustStore.primary.password | string | `""` | Primary truststore password |
-| wso2.deployment.BuildVersion | string | `"4.3.0"` | Build version of the Streaming Integrator |
+| wso2.deployment.BuildVersion | string | `"4.4.0"` | Build version of the Streaming Integrator |
 | wso2.deployment.JKSSecretName | string | `""` | K8s secret name which contains JKS files |
 | wso2.deployment.envs | list | `nil` | Environment variables for the Streaming integrator deployment |
 | wso2.deployment.hostname | string | `"si.wso2.com"` | Hostname of the Streaming Integrator deployment |
@@ -95,7 +95,7 @@ A Helm chart for the deployment of WSO2 Streaming Integrator
 | wso2.deployment.image.digest | string | `""` | Container image digest |
 | wso2.deployment.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | wso2.deployment.image.repository | string | `"wso2/wso2si"` | Container image repository name |
-| wso2.deployment.image.tag | string | `"4.3.0-ubuntu"` | Container image tag |
+| wso2.deployment.image.tag | string | `"4.4.0-ubuntu"` | Container image tag |
 | wso2.deployment.imagePullSecrets | string | `""` | imagePullSecrets for private docker registry |
 | wso2.deployment.mountSiddhiApps | bool | `false` |  |
 | wso2.deployment.probes.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -114,6 +114,20 @@ A Helm chart for the deployment of WSO2 Streaming Integrator
 | wso2.deployment.securityContext.seccompProfile | bool | `true` | Enable/Disable seccomp profile (https://kubernetes.io/docs/tutorials/security/seccomp/) |
 | wso2.deployment.strategy.rollingUpdate.maxSurge | int | `1` | The maximum number of pods that can be scheduled above the desired number of pods. |
 | wso2.deployment.strategy.rollingUpdate.maxUnavailable | int | `0` | The maximum number of pods that can be unavailable during the update. |
+| wso2.gatewayApi.backendTLS.caCertRefs | list | `nil` | CA certificate refs for backend TLS validation. If empty, system CAs are used. |
+| wso2.gatewayApi.backendTLS.enabled | bool | `false` | Enable BackendTLSPolicy for TLS validation between gateway and SI backend. Requires a valid certificate with proper SANs. SI's default self-signed cert (CN=localhost) will cause validation failures — replace it before enabling. |
+| wso2.gatewayApi.backendTLS.hostname | string | `""` | Override the validation hostname. Defaults to the headless service FQDN. |
+| wso2.gatewayApi.enabled | bool | `false` | Enable Gateway API routing (set wso2.ingress.enabled=false when enabling this) |
+| wso2.gatewayApi.gateway.create | bool | `true` | Create a Gateway resource managed by this chart. Set false to reference an existing Gateway. |
+| wso2.gatewayApi.gateway.listenerName | string | `"https"` | Listener name on the Gateway |
+| wso2.gatewayApi.gateway.name | string | `"si-gateway"` | Name of the Gateway resource |
+| wso2.gatewayApi.gateway.namespace | string | `""` | Namespace of an externally-managed Gateway (only used when create=false) |
+| wso2.gatewayApi.gateway.port | int | `443` | HTTPS listener port |
+| wso2.gatewayApi.gateway.tlsSecret | string | `""` | K8s TLS secret name for HTTPS termination. Required when gateway.create=true. |
+| wso2.gatewayApi.gatewayClassName | string | `"eg"` | GatewayClass name (e.g. "eg" for Envoy Gateway) |
+| wso2.gatewayApi.rateLimit.enabled | bool | `false` | Enable rate limiting via Envoy Gateway BackendTrafficPolicy (Envoy Gateway-specific, not portable) |
+| wso2.gatewayApi.rateLimit.requests | int | `100` | Maximum number of requests allowed per unit |
+| wso2.gatewayApi.rateLimit.unit | string | `"Second"` | Time unit for rate limiting (Second, Minute, Hour) |
 | wso2.ingress.annotations | list | `nil` | Ingress annotations |
 | wso2.ingress.backendProtocol | string | `"AUTO_HTTP"` | Controls how the Ingress communicates with backend services |
 | wso2.ingress.enabled | bool | `true` | Enable Ingress for SI |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -2,7 +2,7 @@
 
 ![Version: 4.4.0-0](https://img.shields.io/badge/Version-4.4.0--0-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
-A Helm chart for the deployment of WSO2 Streaming Integrator
+A Helm chart for the deployment of WSO2 Integrator: SI
 
 ## Values
 
@@ -87,10 +87,10 @@ A Helm chart for the deployment of WSO2 Streaming Integrator
 | wso2.config.transport.http.msf4jHttps | int | `9443` |  |
 | wso2.config.trustStore.primary.fileName | string | `"client-truststore.jks"` | Primary truststore file name |
 | wso2.config.trustStore.primary.password | string | `""` | Primary truststore password |
-| wso2.deployment.BuildVersion | string | `"4.4.0"` | Build version of the Streaming Integrator |
+| wso2.deployment.BuildVersion | string | `"4.4.0"` | Build version of WSO2 Integrator: SI |
 | wso2.deployment.JKSSecretName | string | `""` | K8s secret name which contains JKS files |
-| wso2.deployment.envs | list | `nil` | Environment variables for the Streaming integrator deployment |
-| wso2.deployment.hostname | string | `"si.wso2.com"` | Hostname of the Streaming Integrator deployment |
+| wso2.deployment.envs | list | `nil` | Environment variables for the WSO2 Integrator: SI deployment |
+| wso2.deployment.hostname | string | `"si.wso2.com"` | Hostname of the WSO2 Integrator: SI deployment |
 | wso2.deployment.image.containerRegistry | string | `"docker.io"` | Container registry (When running on a local Kubernetes cluster using local image, make this empty) |
 | wso2.deployment.image.digest | string | `""` | Container image digest |
 | wso2.deployment.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -10,8 +10,8 @@
 # ----------------------------------------------------------------------------------------
 
 apiVersion: v1
-appVersion: "4.3.0"
+appVersion: "4.4.0"
 description: A Helm chart for the deployment of WSO2 Streaming Integrator
 name: si
-version: 4.3.0-0
+version: 4.4.0-0
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -11,7 +11,7 @@
 
 apiVersion: v1
 appVersion: "4.4.0"
-description: A Helm chart for the deployment of WSO2 Streaming Integrator
+description: "A Helm chart for the deployment of WSO2 Integrator: SI"
 name: si
 version: 4.4.0-0
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Helm chart for the deployment of WSO2 Streaming Integrator
+# Helm chart for the deployment of WSO2 Integrator: SI
 
 ![Version: 4.4.0-0](https://img.shields.io/badge/Version-4.4.0--0-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
-This module contains the Helm resources required to deploy WSO2 Streaming Integrator in a Kubernetes environment.
+This module contains the Helm resources required to deploy WSO2 Integrator: SI in a Kubernetes environment.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Helm chart for the deployment of WSO2 Streaming Integrator
 
-![Version: 4.3.0-0](https://img.shields.io/badge/Version-4.3.0--0-informational?style=flat-square) ![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
+![Version: 4.4.0-0](https://img.shields.io/badge/Version-4.4.0--0-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
 This module contains the Helm resources required to deploy WSO2 Streaming Integrator in a Kubernetes environment.
 

--- a/confs/deployment.yaml
+++ b/confs/deployment.yaml
@@ -19,7 +19,7 @@ wso2.carbon:
     # value to uniquely identify a server
   id: "$(HOSTNAME)"
     # server name
-  name: WSO2 Streaming Integrator
+  name: "WSO2 Integrator: SI"
     # server type
   type: wso2-si
     # ports used by this server

--- a/values.yaml
+++ b/values.yaml
@@ -253,9 +253,9 @@ wso2:
       seccompProfile: true
       # -- The UID to run the entrypoint of the container process
       runAsUser: ""
-    # -- Hostname of the Streaming Integrator deployment
+    # -- Hostname of the WSO2 Integrator: SI deployment
     hostname: "si.wso2.com"
-    # -- Build version of the Streaming Integrator
+    # -- Build version of WSO2 Integrator: SI
     BuildVersion: "4.4.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
@@ -283,7 +283,7 @@ wso2:
         # -- The maximum number of pods that can be unavailable during the update.
         maxUnavailable: 0
 
-    # These are the minimum resource recommendations for running WSO2 Streaming Integrator
+    # These are the minimum resource recommendations for running WSO2 Integrator: SI
     resources:
       requests:
         # -- The minimum amount of memory that should be allocated for a Pod
@@ -305,7 +305,7 @@ wso2:
           # -- The maximum amount of memory that should be allocated for the JVM
           xmx: "1024m"
 
-    # -- (list) Environment variables for the Streaming integrator deployment
+    # -- (list) Environment variables for the WSO2 Integrator: SI deployment
     envs:
     mountSiddhiApps: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -256,7 +256,7 @@ wso2:
     # -- Hostname of the Streaming Integrator deployment
     hostname: "si.wso2.com"
     # -- Build version of the Streaming Integrator
-    BuildVersion: "4.3.0"
+    BuildVersion: "4.4.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
     # -- imagePullSecrets for private docker registry
@@ -269,7 +269,7 @@ wso2:
       # -- Container image digest
       digest: ""
       # -- Container image tag
-      tag: "4.3.0-ubuntu"
+      tag: "4.4.0-ubuntu"
       # -- Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       pullPolicy: IfNotPresent
 

--- a/values_local.yaml
+++ b/values_local.yaml
@@ -113,9 +113,9 @@ wso2:
       seccompProfile: false
       # -- The UID to run the entrypoint of the container process
       runAsUser: "802"
-    # -- Hostname of the Streaming Integrator deployment
+    # -- Hostname of the WSO2 Integrator: SI deployment
     hostname: "si.wso2.com"
-    # -- Build version of the Streaming Integrator
+    # -- Build version of WSO2 Integrator: SI
     BuildVersion: "4.4.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
@@ -143,7 +143,7 @@ wso2:
         # -- The maximum number of pods that can be unavailable during the update.
         maxUnavailable: 0
 
-    # These are the minimum resource recommendations for running WSO2 Streaming Integrator
+    # These are the minimum resource recommendations for running WSO2 Integrator: SI
     resources:
       requests:
         # -- The minimum amount of memory that should be allocated for a Pod
@@ -165,7 +165,7 @@ wso2:
           # -- The maximum amount of memory that should be allocated for the JVM
           xmx: "1024m"
 
-    # -- (list) Environment variables for the Streaming integrator deployment
+    # -- (list) Environment variables for the WSO2 Integrator: SI deployment
     envs:
     mountSiddhiApps: false
 

--- a/values_local.yaml
+++ b/values_local.yaml
@@ -116,7 +116,7 @@ wso2:
     # -- Hostname of the Streaming Integrator deployment
     hostname: "si.wso2.com"
     # -- Build version of the Streaming Integrator
-    BuildVersion: "4.3.0"
+    BuildVersion: "4.4.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
     # -- imagePullSecrets for private docker registry
@@ -129,7 +129,7 @@ wso2:
       # -- Container image digest
       digest: ""
       # -- Container image tag
-      tag: "4.3.0-ubuntu"
+      tag: "4.4.0-ubuntu"
       # -- Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump chart `appVersion` and `version` to `4.4.0` / `4.4.0-0` in `Chart.yaml`
- Bump `wso2.deployment.BuildVersion` and `image.tag` to `4.4.0` / `4.4.0-ubuntu` in `values.yaml` and `values_local.yaml`
- Update `README.md` version badge
- Regenerate `CONFIG.md` via `helm-docs -f values.yaml -o CONFIG.md`

The 4.3.0 line is preserved on the `4.3.x` branch.

## Test plan
- [x] `helm lint .` passes
- [x] `helm template` renders `docker.io/wso2/wso2si:4.4.0-ubuntu`
- [x] `grep -rn "4\.3\.0" .` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)